### PR TITLE
Load JS* after content to improve page-load performance

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -65,3 +65,6 @@
     <div class="text-center copyright">&copy;{{ site.copyright }}
         Code for Fort Collins</div>
 </footer>
+<script src="https://code.jquery.com/jquery-2.2.3.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
+<script type="text/javascript" src="/assets/js/effects.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,9 +40,6 @@
     <link rel="stylesheet" href="{{ " /css/main.css" | prepend: site.baseurl }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ " /feed.xml" | prepend: site.baseurl | prepend: site.url }}">
 
-    <script src="https://code.jquery.com/jquery-2.2.3.min.js" integrity="sha256-a23g1Nt4dtEYOj7bR+vTu7+T8VP13humZFBJNIYoEJo=" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="/assets/js/effects.js"></script>
     <script>
         (function (i, s, o, g, r, a, m) {
             i['GoogleAnalyticsObject'] = r;


### PR DESCRIPTION
No need to block rendering, jQuery and Bootstrap are fine being loaded at the end.

*except Google Analytics