### PR TITLE
Unpublish bike coop project to hide projects section on home page.

### DIFF
--- a/_posts/projects/2017-05-11-fort-collins-bike-coop.md
+++ b/_posts/projects/2017-05-11-fort-collins-bike-coop.md
@@ -4,6 +4,7 @@ title:  "FCBikeCoop.org"
 date:   2017-05-12 12:00:00 -0700
 image: projects/fcbikecoop.svg
 categories: projects
+published: false
 ---
 
 TODO description.


### PR DESCRIPTION
Because projects had a published post, it displayed  the project section on the home page