### PR TITLE
Jekyll update to fix security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '3.4.4'
+gem 'jekyll', '3.7.4'
 gem 'jekyll-sitemap'
 gem 'jekyll-gist'
 gem 'jekyll-mentions'

--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ sass:
 permalink: pretty
 
 # Plugins
-gems:
+plugins:
   - jekyll-sitemap
   - jekyll-feed
   - jekyll-paginate


### PR DESCRIPTION
These changes fix the Jekyll security alert seen currently on the repository page. This was working on my local dev environment but would be great to confirm on another.