### PR TITLE
Added missing blog posts

### DIFF
--- a/_posts/blog/2017-04-06-idea-submission.md
+++ b/_posts/blog/2017-04-06-idea-submission.md
@@ -7,7 +7,7 @@ categories: blog
 excerpt_separator: <!--more-->
 ---
 
-Code for Fort Collins wants your ideas for making the Fort Collins community better. Whether you're looking for help with providing access to information the City of Fort Collins already has, building out a product that you think the city needs, or just giving us a general problem you have that you think technology could help with.<!--more-->That jog any ideas for you? Give it to us: [http://bit.ly/2nQks7o](http://bit.ly/2nQks7o)
+Code for Fort Collins wants your ideas for making the Fort Collins community better. Whether you're looking for help with providing access to information the City of Fort Collins already has, building out a product that you think the city needs, or just giving us a general problem you have that you think technology could help with.<!--more--> That jog any ideas for you? Give it to us: [http://bit.ly/2nQks7o](http://bit.ly/2nQks7o)
 
 There are no bad ideas. We won't tell anyone about what you told us. Unless it's great. Then we may tell people you gave us the idea. If you give us permission to use your name. :)
 

--- a/_posts/blog/2019-07-20-Quarterly-Leadership-Notes.md
+++ b/_posts/blog/2019-07-20-Quarterly-Leadership-Notes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "We Had Coffee! - Quarterly Leadership Meeting"
-date:   2019-07-18
+date:   2019-07-20
 author: David Hayes
 categories: blog
 ---

--- a/_posts/blog/2019-09-19-board-proposal.md
+++ b/_posts/blog/2019-09-19-board-proposal.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Proposal: Board Procedures"
 date:   2019-09-19
 author: David Hayes
-categories: board, cffc-org
+categories: [blog, board, cffc-org]
 ---
 
 *This is a proposal for formalizing the way that the board of Code for Fort Collins works.*

--- a/_posts/blog/2019-10-03-fcx-version-1.md
+++ b/_posts/blog/2019-10-03-fcx-version-1.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title:  "FCx: We're learning about Fort Collins!"
-date:   2019-10-02
+date:   2019-10-03
 author: David Hayes
-categories: blog, cffc-org, city-of-foco
+categories: [blog, cffc-org, city-of-foco]
 ---
 
 This is a short, late summary of our first event run with the city of Fort Collins on September 5, 2019. Quick summary: the events are codenamed FCx, the next one will be February 6, 2020, and you can find out about [the project at the Our City portal](https://ourcity.fcgov.com/open-data).

--- a/_posts/blog/2019-11-15-board-meeting-summary.md
+++ b/_posts/blog/2019-11-15-board-meeting-summary.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title:  Q4 Board Meeting: Some Notes
+title:  "Q4 Board Meeting: Some Notes"
 date:   2019-11-15
 author: David Hayes
-categories: board, cffc-org
+categories: [blog, board, cffc-org]
 ---
 
 This is mostly my sharing my disorganized notes from the meeting, so you might be asking David (me) for more details if any of this is unclear.


### PR DESCRIPTION
- Added blog category to the blog posts that weren't showing on the blog page. We aren't really linking to them weirdly, they just get filtered out if they don't have the blog category.

    One of them did have the blog category but it wasn't formatted correctly so it also wasn't showing on the site.

    I learned that YAML arrays or collections can either be comma separated values between square brackets or on new lines using the dash space notation.

    Collection notation: 
    ```yaml
    categories:
      - blog
      - another-category
      - one-more-category
    ```
    Optional collection notation:
    ```yaml
    categories: [blog, another-category, one-more-category]
    ```

- Added quotations around one of the titles. Double quotes escape certain characters inside a string in YAML. In this case it escaped the colon in the title.

- Added a space after one of the excerpt separators in a past post as it was rendering as no space between the previous and next sentence.

- Updated the post date on a couple posts to match the file date/post url.

Fixes #154 